### PR TITLE
Don't add duplicate keys to the required array on JSON schema

### DIFF
--- a/src/schemas/json.js
+++ b/src/schemas/json.js
@@ -22,8 +22,8 @@ function getUniqueKeys (a, b, c) {
         // Value is optional, it doesn't exist in A but exists in B(n)
         c.splice(cIndex, 1)
       }
-    } else {
-      // Value is required, it exists in both B and A
+    } else if (cIndex === -1) {
+      // Value is required, it exists in both B and A, and is not yet present in C
       c.push(value)
     }
   }


### PR DESCRIPTION
Hey @Nijikokun!

First of all, great work!

I was trying the JSON Schema generator with an array of more than two objects and the returned `required` array had the keys duplicated, so here's a quick fix to address that problem.

Thanks!