### PR TITLE
Adding integer validation keyword for numeric instances and appropria…

### DIFF
--- a/src/schemas/json.js
+++ b/src/schemas/json.js
@@ -15,6 +15,7 @@ function getPropertyFormat(value) {
 function getPropertyType(value) {
   var type = Type.string(value).toLowerCase()
 
+  if (type === 'number') return Number.isInteger(value) ? 'integer' : type
   if (type === 'date') return 'string'
   if (type === 'regexp') return 'string'
   if (type === 'function') return 'string'

--- a/test/json.js
+++ b/test/json.js
@@ -38,6 +38,18 @@ describe('JSON', function () {
     it('.items.properties.tags should be an object', function () {
       schema.items.properties.tags.should.be.type('object')
     })
+
+    it('.items.properties.id should be of type [integer]', function () {
+      schema.items.properties.id.type.should.equal('integer')
+    })
+
+    it('.items.properties.price should be of type [number]', function () {
+      schema.items.properties.price.type.should.equal('number')
+    })
+
+    it('.items.properties.dimensions.properties.length should be of type [integer, number]', function () {
+      schema.items.properties.dimensions.properties.length.type.should.eql(['integer', 'number'])
+    })
   })
 
   describe('Property Checks', function () {
@@ -55,8 +67,8 @@ describe('JSON', function () {
       schema.properties.should.be.type('object')
     })
 
-    it('.properties.id should be of type [number]', function () {
-      schema.properties.id.type.should.equal('number')
+    it('.properties.id should be of type [integer]', function () {
+      schema.properties.id.type.should.equal('integer')
     })
 
     it('.properties.slug should be of type [string]', function () {


### PR DESCRIPTION
…te tests. Hold #39 

One thing to note is that '1.0' is considered an integer because of JavaScript quirkiness. A user should use a number greater than '0' in the fractional part, for example '1.1'.