### PR TITLE
Schema reads + saves string of numbers incorrectly as date

### DIFF
--- a/src/schemas/mongoose.js
+++ b/src/schemas/mongoose.js
@@ -54,7 +54,7 @@ module.exports = function Process (object, output) {
       type = Type.string(value).toLowerCase()
     }
 
-    if (type === 'string' && Utils.isDate(value)) {
+    if (type === 'string' && !/^[0-9]+$/.test(value) && Utils.isDate(value)) {
       type = 'date'
     }
 


### PR DESCRIPTION
Generating a schema that runs into a string of numbers should opt for the most likely case of them being an ID or index, rather than a date.

**Example**:  
Currently `"67260"` will be not only typed, but also converted to and saved as an ISO date changing it into `ISODate("67260-01-01T05:00:00Z")`