### PR TITLE
Array of array json schema support added

### DIFF
--- a/src/schemas/json.js
+++ b/src/schemas/json.js
@@ -94,7 +94,7 @@ function processArray(array, output, nested) {
   }
 
   // Process each item depending
-  if (typeof output.items.oneOf !== 'undefined' || type === 'object') {
+  if (typeof output.items.oneOf !== 'undefined' || type === 'object' || type === 'array') {
     for (var itemIndex = 0, itemLength = array.length; itemIndex < itemLength; itemIndex++) {
       var value = array[itemIndex]
       var itemType = getPropertyType(value)
@@ -123,11 +123,10 @@ function processArray(array, output, nested) {
           arrayItem = tempObj
         }
         output.items.oneOf.push(arrayItem)
-      } else {
-        if (output.items.type !== 'object') {
-          continue;
-        }
+      } else if (output.items.type === 'object') {
         output.items.properties = arrayItem
+      } else if(output.items.type === 'array') {
+        output.items.items = arrayItem
       }
     }
   }

--- a/test/fixtures/advanced.js
+++ b/test/fixtures/advanced.js
@@ -4,6 +4,12 @@ module.exports = [
     "name": "An ice sculpture",
     "price": 12.50,
     "tags": ["cold", "ice"],
+    "filters": [
+      [{
+        "operator": "EQ",
+        "value": "Ice Cold"
+      }]
+    ],
     "dimensions": {
       "length": 7.0,
       "width": 12.0,

--- a/test/json.js
+++ b/test/json.js
@@ -39,6 +39,12 @@ describe('JSON', function () {
       schema.items.properties.tags.should.be.type('object')
     })
 
+    it('.items.properties.filters.items should be an array of array', function () {
+      schema.items.properties.filters.type.should.eql('array')
+      schema.items.properties.filters.items.type.should.eql('array')
+      schema.items.properties.filters.items.items.type.should.eql('object')
+    })
+
     it('.items.properties.id should be of type [integer]', function () {
       schema.items.properties.id.type.should.equal('integer')
     })


### PR DESCRIPTION
Fix for Issue: https://github.com/nijikokun/generate-schema/issues/55
With current implementation we array of array is not handled added support for the same.

**Input**
```
{
    "filters": [
        [
            {
                "operator": "EQ",
                "value": "Ice Cold"
            }
        ]
    ]
}
```

**Output before fix**
```
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "type": "object",
    "properties": {
        "filters": {
            "type": "array",
            "items": {
                "type": "array"
            }
        }
    },
    "required": [
        "filters"
    ]
}
```

**Output after fix**
```
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "type": "object",
    "properties": {
        "filters": {
            "type": "array",
            "items": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {
                        "operator": {
                            "type": "string"
                        },
                        "value": {
                            "type": "string"
                        }
                    }
                }
            }
        }
    },
    "required": [
        "filters"
    ]
}
```

